### PR TITLE
Make "filter" field optional for creating webhooks

### DIFF
--- a/Source/Webhook/WebHookClient+Sync.swift
+++ b/Source/Webhook/WebHookClient+Sync.swift
@@ -38,7 +38,7 @@ extension WebhookClient {
     /// - parameter event: The event type for the webhook.
     /// - parameter filter: The filter that defines the webhook scope.
     /// - returns: Webhook
-    public func create(name: String, targetUrl: String, resource: String, event: String, filter: String) throws -> Webhook {
+    public func create(name: String, targetUrl: String, resource: String, event: String, filter: String?) throws -> Webhook {
 		return try SyncUtil.getObject(name, targetUrl, resource, event, filter, async: create)
     }
     

--- a/Source/Webhook/WebhookClient.swift
+++ b/Source/Webhook/WebhookClient.swift
@@ -54,7 +54,7 @@ open class WebhookClient: CompletionHandlerType<Webhook> {
     /// - parameter queue: The queue on which the completion handler is dispatched.
     /// - parameter completionHandler: A closure to be executed once the request has finished.
     /// - returns: Void
-    open func create(name: String, targetUrl: String, resource: String, event: String, filter: String, queue: DispatchQueue? = nil, completionHandler: @escaping ObjectHandler) {
+    open func create(name: String, targetUrl: String, resource: String, event: String, filter: String?, queue: DispatchQueue? = nil, completionHandler: @escaping ObjectHandler) {
         let body = RequestParameter([
             "name": name,
             "targetUrl": targetUrl,


### PR DESCRIPTION
This field is optional according to the documentation at https://developer.ciscospark.com/endpoint-webhooks-post.html and we have confirmed that leaving it nil results in a successful create operation.